### PR TITLE
Fix for CE-74 Breaker Helm being marked as cloak.

### DIFF
--- a/items/armor/armor.json
+++ b/items/armor/armor.json
@@ -523,7 +523,7 @@
 		"name": "CE-74 Breaker",
 		"description": "A domestic version of this armor is available for citizens who wish to perform efficient home renovation projects.",
 		"type": 1,
-		"slot": 1,
+		"slot": 2,
 		"armor_rating": 100,
 		"speed": 100,
 		"stamina_regen": 100,

--- a/items/armor/armor.json
+++ b/items/armor/armor.json
@@ -522,11 +522,11 @@
 	"3996028128": {
 		"name": "CE-74 Breaker",
 		"description": "A domestic version of this armor is available for citizens who wish to perform efficient home renovation projects.",
-		"type": 1,
+		"type": 0,
 		"slot": 2,
-		"armor_rating": 100,
-		"speed": 100,
-		"stamina_regen": 100,
+		"armor_rating": 50,
+		"speed": 550,
+		"stamina_regen": 125,
 		"passive": 0
 	},
 	"2546928266": {


### PR DESCRIPTION
CE-74 Breaker Helm was incorrectly mapped as a Cloak instead of a helm.