### PR TITLE
Update biomes, environmentals, and planets for Escalation of Freedom

### DIFF
--- a/planets/biomes.json
+++ b/planets/biomes.json
@@ -43,8 +43,8 @@
 		"name": "Tundra",
 		"description": "A perennially chilly climate has allowed short, colourful shrubs to flourish across this planet's surface."
 	},
-	"swamp": {
-		"name": "Swamp",
+	"wasteland": {
+		"name": "Wasteland",
 		"description": "The lifeless grey of this planet is interrupted only by the violet flowers that grow from strange, parasitic outcroppings."
 	},
 	"desolate": {
@@ -67,8 +67,12 @@
 		"name": "Toxic",
 		"description": "Dense, toxic fumes from deep within the planet's crust seep out of cracks in the earth and coat the ground in a sickly haze."
 	},
-	"dense_jungle": {
-		"name": "Dense Jungle",
+	"swamp": {
+		"name": "Swamp",
 		"description": "Tall, gnarled trees flourish across the surface of this forested world. Sunlight filters past dangling vines, to the saturated udnergrowth below."
+	},
+	"foggy_swamp": {
+		"name": "Foggy Swamp",
+		"description": "Squelching mud, twisting roots; the odor of rot and anarchy. A teeming, endless morass."
 	}
 }

--- a/planets/biomes.json
+++ b/planets/biomes.json
@@ -66,5 +66,9 @@
 	"toxic": {
 		"name": "Toxic",
 		"description": "Dense, toxic fumes from deep within the planet's crust seep out of cracks in the earth and coat the ground in a sickly haze."
+	},
+	"dense_jungle":{
+		"name": "Dense Jungle",
+		"description": "Tall, gnarled trees flourish across the surface of this forested world. Sunlight filters past dangling vines, to the saturated udnergrowth below."
 	}
 }

--- a/planets/biomes.json
+++ b/planets/biomes.json
@@ -67,7 +67,7 @@
 		"name": "Toxic",
 		"description": "Dense, toxic fumes from deep within the planet's crust seep out of cracks in the earth and coat the ground in a sickly haze."
 	},
-	"dense_jungle":{
+	"dense_jungle": {
 		"name": "Dense Jungle",
 		"description": "Tall, gnarled trees flourish across the surface of this forested world. Sunlight filters past dangling vines, to the saturated udnergrowth below."
 	}

--- a/planets/environmentals.json
+++ b/planets/environmentals.json
@@ -41,7 +41,7 @@
 	},
 	"acid_storms": {
 		"name": "Acid Storms",
-		"description": "Violent acid storms reduce visibility."
+		"description": "Corrosive acid storms temporarily reduce armor effectiveness for both enemy and friendly units."
 	},
 	"volcanic_activity": {
 		"name": "Volcanic Activity",

--- a/planets/planets.json
+++ b/planets/planets.json
@@ -233,9 +233,8 @@
 	"9": {
 		"name": "Fornskogur II",
 		"sector": "Barnard",
-		"biome": "jungle",
+		"biome": "dense_jungle",
 		"environmentals": [
-			"volcanic_activity",
 			"rainstorms"
 		],
 		"names": {
@@ -1099,9 +1098,9 @@
 	"43": {
 		"name": "Barabos",
 		"sector": "Marspira",
-		"biome": "icemoss",
+		"biome": "dense_jungle",
 		"environmentals": [
-			"extreme_cold"
+			"rainstorms"
 		],
 		"names": {
 			"en-US": "BARABOS",
@@ -1302,10 +1301,9 @@
 	"51": {
 		"name": "Ivis",
 		"sector": "Celeste",
-		"biome": "winter",
+		"biome": "dense_jungle",
 		"environmentals": [
-			"extreme_cold",
-			"blizzards"
+			"rainstorms"
 		],
 		"names": {
 			"en-US": "IVIS",
@@ -1480,10 +1478,9 @@
 	"58": {
 		"name": "Parsh",
 		"sector": "Rictus",
-		"biome": "winter",
+		"biome": "dense_jungle",
 		"environmentals": [
-			"extreme_cold",
-			"blizzards"
+			"rainstorms"
 		],
 		"names": {
 			"en-US": "PARSH",
@@ -2580,9 +2577,8 @@
 	"101": {
 		"name": "East Iridium Trading Bay",
 		"sector": "Tarragon",
-		"biome": "jungle",
+		"biome": "dense_jungle",
 		"environmentals": [
-			"volcanic_activity",
 			"rainstorms"
 		],
 		"names": {
@@ -3166,10 +3162,9 @@
 	"124": {
 		"name": "Bore Rock",
 		"sector": "Falstaff",
-		"biome": "desolate",
+		"biome": "dense_jungle",
 		"environmentals": [
-			"intense_heat",
-			"fire_tornadoes"
+			"rainstorms"
 		],
 		"names": {
 			"en-US": "BORE ROCK",
@@ -3649,10 +3644,9 @@
 	"143": {
 		"name": "Asperoth Prime",
 		"sector": "Akira",
-		"biome": "desolate",
+		"biome": "dense_jungle",
 		"environmentals": [
-			"intense_heat",
-			"fire_tornadoes"
+			"rainstorms"
 		],
 		"names": {
 			"en-US": "ASPEROTH PRIME",
@@ -3829,9 +3823,8 @@
 	"150": {
 		"name": "Caph",
 		"sector": "Theseus",
-		"biome": "jungle",
+		"biome": "dense_jungle",
 		"environmentals": [
-			"volcanic_activity",
 			"rainstorms"
 		],
 		"names": {
@@ -4136,9 +4129,8 @@
 	"162": {
 		"name": "Clasa",
 		"sector": "Tanis",
-		"biome": "jungle",
+		"biome": "dense_jungle",
 		"environmentals": [
-			"volcanic_activity",
 			"rainstorms"
 		],
 		"names": {
@@ -4365,9 +4357,9 @@
 	"171": {
 		"name": "Gacrux",
 		"sector": "Jin Xi",
-		"biome": "tundra",
+		"biome": "dense_jungle",
 		"environmentals": [
-			"none"
+			"rainstorms"
 		],
 		"names": {
 			"en-US": "GACRUX",
@@ -4543,10 +4535,9 @@
 	"178": {
 		"name": "Haldus",
 		"sector": "Ferris",
-		"biome": "moon",
+		"biome": "dense_jungle",
 		"environmentals": [
-			"extreme_cold",
-			"meteor_storms"
+			"rainstorms"
 		],
 		"names": {
 			"en-US": "HALDUS",
@@ -5339,9 +5330,9 @@
 	"209": {
 		"name": "Nabatea Secundus",
 		"sector": "L'estrade",
-		"biome": "rainforest",
+		"biome": "dense_jungle",
 		"environmentals": [
-			"ion_storms"
+			"rainstorms"
 		],
 		"names": {
 			"en-US": "NABATEA SECUNDUS",
@@ -5568,9 +5559,8 @@
 	"218": {
 		"name": "Pherkad Secundus",
 		"sector": "Farsight",
-		"biome": "highlands",
+		"biome": "dense_jungle",
 		"environmentals": [
-			"thick_fog",
 			"rainstorms"
 		],
 		"names": {
@@ -5800,9 +5790,9 @@
 	"227": {
 		"name": "Seasse",
 		"sector": "Omega",
-		"biome": "rainforest",
+		"biome": "dense_jungle",
 		"environmentals": [
-			"ion_storms"
+			"rainstorms"
 		],
 		"names": {
 			"en-US": "SEASSE",
@@ -6362,9 +6352,9 @@
 	"249": {
 		"name": "X-45",
 		"sector": "Ymir",
-		"biome": "swamp",
+		"biome": "dense_jungle",
 		"environmentals": [
-			"thick_fog"
+			"rainstorms"
 		],
 		"names": {
 			"en-US": "X-45",

--- a/planets/planets.json
+++ b/planets/planets.json
@@ -664,10 +664,9 @@
 	"26": {
 		"name": "Nublaria I",
 		"sector": "Celeste",
-		"biome": "jungle",
+		"biome": "foggy_swamp",
 		"environmentals": [
-			"volcanic_activity",
-			"rainstorms"
+			"thick_fog"
 		],
 		"names": {
 			"en-US": "NUBLARIA I",
@@ -918,7 +917,7 @@
 	"36": {
 		"name": "Solghast",
 		"sector": "Gothmar",
-		"biome": "wasteland",
+		"biome": "foggy_swamp",
 		"environmentals": [
 			"thick_fog"
 		],
@@ -1046,9 +1045,9 @@
 	"41": {
 		"name": "Atrama",
 		"sector": "Idun",
-		"biome": "rainforest",
+		"biome": "foggy_swamp",
 		"environmentals": [
-			"ion_storms"
+			"thick_fog"
 		],
 		"names": {
 			"en-US": "ATRAMA",
@@ -1705,10 +1704,9 @@
 	"67": {
 		"name": "Tarsh",
 		"sector": "Marspira",
-		"biome": "winter",
+		"biome": "foggy_swamp",
 		"environmentals": [
-			"extreme_cold",
-			"blizzards"
+			"thick_fog"
 		],
 		"names": {
 			"en-US": "TARSH",
@@ -1808,10 +1806,9 @@
 	"71": {
 		"name": "Ratch",
 		"sector": "Iptus",
-		"biome": "mesa",
+		"biome": "foggy_swamp",
 		"environmentals": [
-			"intense_heat",
-			"sandstorms"
+			"thick_fog"
 		],
 		"names": {
 			"en-US": "RATCH",
@@ -2216,7 +2213,7 @@
 	"87": {
 		"name": "Bashyr",
 		"sector": "Gallux",
-		"biome": "wasteland",
+		"biome": "foggy_swamp",
 		"environmentals": [
 			"thick_fog"
 		],
@@ -2241,10 +2238,9 @@
 	"88": {
 		"name": "Regnus",
 		"sector": "Morgon",
-		"biome": "jungle",
+		"biome": "foggy_swamp",
 		"environmentals": [
-			"volcanic_activity",
-			"rainstorms"
+			"thick_fog"
 		],
 		"names": {
 			"en-US": "REGNUS",
@@ -4372,10 +4368,9 @@
 	"172": {
 		"name": "Gar Haren",
 		"sector": "Jin Xi",
-		"biome": "jungle",
+		"biome": "foggy_swamp",
 		"environmentals": [
-			"volcanic_activity",
-			"rainstorms"
+			"thick_fog"
 		],
 		"names": {
 			"en-US": "GAR HAREN",
@@ -4757,10 +4752,9 @@
 	"187": {
 		"name": "Khandark",
 		"sector": "Guang",
-		"biome": "winter",
+		"biome": "foggy_swamp",
 		"environmentals": [
-			"extreme_cold",
-			"blizzards"
+			"thick_fog"
 		],
 		"names": {
 			"en-US": "KHANDARK",
@@ -4783,10 +4777,9 @@
 	"188": {
 		"name": "Klaka 5",
 		"sector": "Alstrad",
-		"biome": "jungle",
+		"biome": "foggy_swamp",
 		"environmentals": [
-			"volcanic_activity",
-			"rainstorms"
+			"thick_fog"
 		],
 		"names": {
 			"en-US": "KLAKA 5",
@@ -5217,10 +5210,9 @@
 	"205": {
 		"name": "Merga IV",
 		"sector": "Valdis",
-		"biome": "winter",
+		"biome": "foggy_swamp",
 		"environmentals": [
-			"extreme_cold",
-			"blizzards"
+			"thick_fog"
 		],
 		"names": {
 			"en-US": "MERGA IV",
@@ -5828,10 +5820,9 @@
 	"229": {
 		"name": "Setia",
 		"sector": "Omega",
-		"biome": "mesa",
+		"biome": "foggy_swamp",
 		"environmentals": [
-			"intense_heat",
-			"sandstorms"
+			"thick_fog"
 		],
 		"names": {
 			"en-US": "SETIA",
@@ -6465,10 +6456,9 @@
 	"254": {
 		"name": "Skitter",
 		"sector": "Hawking",
-		"biome": "highlands",
+		"biome": "foggy_swamp",
 		"environmentals": [
-			"thick_fog",
-			"rainstorms"
+			"thick_fog"
 		],
 		"names": {
 			"en-US": "SKITTER",

--- a/planets/planets.json
+++ b/planets/planets.json
@@ -232,7 +232,7 @@
 	"9": {
 		"name": "Fornskogur II",
 		"sector": "Barnard",
-		"biome": "dense_jungle",
+		"biome": "swamp",
 		"environmentals": [
 			"rainstorms"
 		],
@@ -766,7 +766,7 @@
 	"30": {
 		"name": "Veil",
 		"sector": "Barnard",
-		"biome": "swamp",
+		"biome": "wasteland",
 		"environmentals": [
 			"thick_fog"
 		],
@@ -918,7 +918,7 @@
 	"36": {
 		"name": "Solghast",
 		"sector": "Gothmar",
-		"biome": "swamp",
+		"biome": "wasteland",
 		"environmentals": [
 			"thick_fog"
 		],
@@ -1096,7 +1096,7 @@
 	"43": {
 		"name": "Barabos",
 		"sector": "Marspira",
-		"biome": "dense_jungle",
+		"biome": "swamp",
 		"environmentals": [
 			"rainstorms"
 		],
@@ -1299,7 +1299,7 @@
 	"51": {
 		"name": "Ivis",
 		"sector": "Celeste",
-		"biome": "dense_jungle",
+		"biome": "swamp",
 		"environmentals": [
 			"rainstorms"
 		],
@@ -1475,7 +1475,7 @@
 	"58": {
 		"name": "Parsh",
 		"sector": "Rictus",
-		"biome": "dense_jungle",
+		"biome": "swamp",
 		"environmentals": [
 			"rainstorms"
 		],
@@ -1962,7 +1962,7 @@
 	"77": {
 		"name": "Cirrus",
 		"sector": "Orion",
-		"biome": "swamp",
+		"biome": "wasteland",
 		"environmentals": [
 			"thick_fog"
 		],
@@ -2216,7 +2216,7 @@
 	"87": {
 		"name": "Bashyr",
 		"sector": "Gallux",
-		"biome": "swamp",
+		"biome": "wasteland",
 		"environmentals": [
 			"thick_fog"
 		],
@@ -2522,7 +2522,7 @@
 	"99": {
 		"name": "Alderidge Cove",
 		"sector": "Guang",
-		"biome": "swamp",
+		"biome": "wasteland",
 		"environmentals": [
 			"thick_fog"
 		],
@@ -2572,7 +2572,7 @@
 	"101": {
 		"name": "East Iridium Trading Bay",
 		"sector": "Tarragon",
-		"biome": "dense_jungle",
+		"biome": "swamp",
 		"environmentals": [
 			"rainstorms"
 		],
@@ -2876,7 +2876,7 @@
 	"113": {
 		"name": "Aesir Pass",
 		"sector": "Hydra",
-		"biome": "swamp",
+		"biome": "wasteland",
 		"environmentals": [
 			"thick_fog"
 		],
@@ -2926,7 +2926,7 @@
 	"115": {
 		"name": "Penta",
 		"sector": "Lacaille",
-		"biome": "swamp",
+		"biome": "wasteland",
 		"environmentals": [
 			"thick_fog"
 		],
@@ -3131,9 +3131,9 @@
 	"123": {
 		"name": "Socorro III",
 		"sector": "Falstaff",
-		"biome": "ethereal",
+		"biome": "foggy_swamp",
 		"environmentals": [
-			"none"
+			"thick_fog"
 		],
 		"names": {
 			"en-US": "SOCORRO III",
@@ -3156,7 +3156,7 @@
 	"124": {
 		"name": "Bore Rock",
 		"sector": "Falstaff",
-		"biome": "dense_jungle",
+		"biome": "swamp",
 		"environmentals": [
 			"rainstorms"
 		],
@@ -3486,7 +3486,7 @@
 	"137": {
 		"name": "Ain-5",
 		"sector": "Hanzo",
-		"biome": "swamp",
+		"biome": "wasteland",
 		"environmentals": [
 			"thick_fog"
 		],
@@ -3561,7 +3561,7 @@
 	"140": {
 		"name": "Alaraph",
 		"sector": "Akira",
-		"biome": "swamp",
+		"biome": "wasteland",
 		"environmentals": [
 			"thick_fog"
 		],
@@ -3637,7 +3637,7 @@
 	"143": {
 		"name": "Asperoth Prime",
 		"sector": "Akira",
-		"biome": "dense_jungle",
+		"biome": "swamp",
 		"environmentals": [
 			"rainstorms"
 		],
@@ -3815,7 +3815,7 @@
 	"150": {
 		"name": "Caph",
 		"sector": "Theseus",
-		"biome": "dense_jungle",
+		"biome": "swamp",
 		"environmentals": [
 			"rainstorms"
 		],
@@ -3917,7 +3917,7 @@
 	"154": {
 		"name": "Mort",
 		"sector": "Xzar",
-		"biome": "swamp",
+		"biome": "wasteland",
 		"environmentals": [
 			"thick_fog"
 		],
@@ -4119,7 +4119,7 @@
 	"162": {
 		"name": "Clasa",
 		"sector": "Tanis",
-		"biome": "dense_jungle",
+		"biome": "swamp",
 		"environmentals": [
 			"rainstorms"
 		],
@@ -4347,7 +4347,7 @@
 	"171": {
 		"name": "Gacrux",
 		"sector": "Jin Xi",
-		"biome": "dense_jungle",
+		"biome": "swamp",
 		"environmentals": [
 			"rainstorms"
 		],
@@ -4500,7 +4500,7 @@
 	"177": {
 		"name": "Haka",
 		"sector": "Leo",
-		"biome": "swamp",
+		"biome": "wasteland",
 		"environmentals": [
 			"thick_fog"
 		],
@@ -4525,7 +4525,7 @@
 	"178": {
 		"name": "Haldus",
 		"sector": "Ferris",
-		"biome": "dense_jungle",
+		"biome": "swamp",
 		"environmentals": [
 			"rainstorms"
 		],
@@ -5319,7 +5319,7 @@
 	"209": {
 		"name": "Nabatea Secundus",
 		"sector": "L'estrade",
-		"biome": "dense_jungle",
+		"biome": "swamp",
 		"environmentals": [
 			"rainstorms"
 		],
@@ -5370,7 +5370,7 @@
 	"211": {
 		"name": "Nivel 43",
 		"sector": "Mirin",
-		"biome": "swamp",
+		"biome": "wasteland",
 		"environmentals": [
 			"thick_fog"
 		],
@@ -5446,7 +5446,7 @@
 	"214": {
 		"name": "Pandion-XXIV",
 		"sector": "Jin Xi",
-		"biome": "swamp",
+		"biome": "wasteland",
 		"environmentals": [
 			"thick_fog"
 		],
@@ -5548,7 +5548,7 @@
 	"218": {
 		"name": "Pherkad Secundus",
 		"sector": "Farsight",
-		"biome": "dense_jungle",
+		"biome": "swamp",
 		"environmentals": [
 			"rainstorms"
 		],
@@ -5778,7 +5778,7 @@
 	"227": {
 		"name": "Seasse",
 		"sector": "Omega",
-		"biome": "dense_jungle",
+		"biome": "swamp",
 		"environmentals": [
 			"rainstorms"
 		],
@@ -5930,7 +5930,7 @@
 	"233": {
 		"name": "Skat Bay",
 		"sector": "Xi Tauri",
-		"biome": "swamp",
+		"biome": "wasteland",
 		"environmentals": [
 			"thick_fog"
 		],
@@ -6108,7 +6108,7 @@
 	"240": {
 		"name": "Troost",
 		"sector": "Trigon",
-		"biome": "swamp",
+		"biome": "wasteland",
 		"environmentals": [
 			"thick_fog"
 		],
@@ -6338,7 +6338,7 @@
 	"249": {
 		"name": "X-45",
 		"sector": "Ymir",
-		"biome": "dense_jungle",
+		"biome": "swamp",
 		"environmentals": [
 			"rainstorms"
 		],

--- a/planets/planets.json
+++ b/planets/planets.json
@@ -209,7 +209,6 @@
 		"sector": "Barnard",
 		"biome": "toxic",
 		"environmentals": [
-			"intense_heat",
 			"acid_storms"
 		],
 		"names": {
@@ -464,7 +463,6 @@
 		"sector": "Idun",
 		"biome": "toxic",
 		"environmentals": [
-			"intense_heat",
 			"acid_storms"
 		],
 		"names": {
@@ -1328,7 +1326,6 @@
 		"sector": "Celeste",
 		"biome": "toxic",
 		"environmentals": [
-			"intense_heat",
 			"acid_storms"
 		],
 		"names": {
@@ -1916,7 +1913,6 @@
 		"sector": "Falstaff",
 		"biome": "toxic",
 		"environmentals": [
-			"intense_heat",
 			"acid_storms"
 		],
 		"names": {
@@ -2145,7 +2141,6 @@
 		"sector": "Ursa",
 		"biome": "toxic",
 		"environmentals": [
-			"intense_heat",
 			"acid_storms"
 		],
 		"names": {
@@ -3062,7 +3057,6 @@
 		"sector": "Arturion",
 		"biome": "toxic",
 		"environmentals": [
-			"intense_heat",
 			"acid_storms"
 		],
 		"names": {
@@ -3265,7 +3259,6 @@
 		"sector": "Borgus",
 		"biome": "toxic",
 		"environmentals": [
-			"intense_heat",
 			"acid_storms"
 		],
 		"names": {
@@ -3697,7 +3690,6 @@
 		"sector": "Guang",
 		"biome": "toxic",
 		"environmentals": [
-			"intense_heat",
 			"acid_storms"
 		],
 		"names": {
@@ -3977,7 +3969,6 @@
 		"sector": "Andromeda",
 		"biome": "toxic",
 		"environmentals": [
-			"intense_heat",
 			"acid_storms"
 		],
 		"names": {
@@ -4079,7 +4070,6 @@
 		"sector": "Lacaille",
 		"biome": "toxic",
 		"environmentals": [
-			"intense_heat",
 			"acid_storms"
 		],
 		"names": {
@@ -4923,7 +4913,6 @@
 		"sector": "Quintus",
 		"biome": "toxic",
 		"environmentals": [
-			"intense_heat",
 			"acid_storms"
 		],
 		"names": {
@@ -5766,7 +5755,6 @@
 		"sector": "Rigel",
 		"biome": "toxic",
 		"environmentals": [
-			"intense_heat",
 			"acid_storms"
 		],
 		"names": {
@@ -5868,7 +5856,6 @@
 		"sector": "Xi Tauri",
 		"biome": "toxic",
 		"environmentals": [
-			"intense_heat",
 			"acid_storms"
 		],
 		"names": {
@@ -6251,7 +6238,6 @@
 		"sector": "Ymir",
 		"biome": "toxic",
 		"environmentals": [
-			"intense_heat",
 			"acid_storms"
 		],
 		"names": {


### PR DESCRIPTION
Updated the description for "Acid Storms" to match the new in-game description.
Removed "Intense Heat" from Toxic planets to match changes.

I decided to rename "Dense Jungle" to "Swamp" to keep it in line with what AH has been calling the biome, and I changed the old "Swamp" to "Wasteland" to match the lifeless description.

Also added a "Foggy Swamp" biome, but currently only applied it to Socorro III, since that's the only one I can see that has it and need more data to finish updating planets.