### PR TITLE
Add value type 4

### DIFF
--- a/assignments/tasks/task/valueTypes.json
+++ b/assignments/tasks/task/valueTypes.json
@@ -2,6 +2,7 @@
 	"1": "race",
 	"2": "unknown",
 	"3": "goal",
+	"4": "unit_id",
 	"5": "item_id",
 	"11": "liberate",
 	"12": "planet_index"


### PR DESCRIPTION
Type 4 seems to be for the unit id for the specific target of an eradicate assignment based on 4 only being filled out for the Bile Titan assignment.