### PR TITLE
Fix Typo

### DIFF
--- a/planets/biomes.json
+++ b/planets/biomes.json
@@ -69,7 +69,7 @@
 	},
 	"swamp": {
 		"name": "Swamp",
-		"description": "Tall, gnarled trees flourish across the surface of this forested world. Sunlight filters past dangling vines, to the saturated udnergrowth below."
+		"description": "Tall, gnarled trees flourish across the surface of this forested world. Sunlight filters past dangling vines, to the saturated undergrowth below."
 	},
 	"foggy_swamp": {
 		"name": "Foggy Swamp",


### PR DESCRIPTION
Fix a typo in Swamp biome description.

Closes #61 