### PR TITLE
Update planetEffects.json

### DIFF
--- a/effects/planetEffects.json
+++ b/effects/planetEffects.json
@@ -141,8 +141,8 @@
 	},
 	"1242": {
 		"galacticEffectId": 1242,
-		"name": "MOVING WORLD",
-		"description": "This world is moving and is estimated to impact Super Earth."
+		"name": "MOVING PLANET",
+		"description": "This planet is moving and is estimated to impact Super Earth."
 	},
 	"1245":{
 		"galacticEffectId": 1245,

--- a/effects/planetEffects.json
+++ b/effects/planetEffects.json
@@ -142,6 +142,6 @@
 	"1242": {
 		"galacticEffectId": 1242,
 		"name": "MOVING SINGULARITY",
-		"description": "The singluarity is moving and is estimated to impact Super Earth."
+		"description": "The singularity is moving and is estimated to impact Super Earth."
 	}
 }

--- a/effects/planetEffects.json
+++ b/effects/planetEffects.json
@@ -144,9 +144,14 @@
 		"name": "MOVING PLANET",
 		"description": "This planet is moving and is estimated to impact Super Earth."
 	},
-	"1245":{
+	"1245": {
 		"galacticEffectId": 1245,
 		"name": "PREDATOR STRAIN",
 		"description": "A Gloom-enhanced strain of Terminids has been reported on this planet. SEAF patrols have been lured into ambushes, and picked off by unseen assailants. Every ounce of a Helldiver's superior senses will be required to hunt down this dangerous threat."
+	},
+	"1249": {
+		"galacticEffectId": 1249,
+		"name": "THE INCINERATION CORPS",
+		"description": "An Automaton unit equipped with flame throwers and incendiary ammunition is active on this planet. These wanton arsonists will not rest until they have razed all that humankind holds dear."
 	}
 }

--- a/effects/planetEffects.json
+++ b/effects/planetEffects.json
@@ -56,12 +56,12 @@
 	},
 	"1202": {
 		"galacticEffectId": 1202,
-		"name": "THE JET BRIGADE",
+		"name": "THE JET BRIGADE (Enemies)",
 		"description": "The Automatons have deployed a new series of specialized models on this planet. These upgraded bots utilize stolen Jump Pack technology, heartlessly pillaged from the bodies of fallen Helldivers and reverse-engineered into something nearly unrecognizeable."
 	},
 	"1203": {
 		"galacticEffectId": 1203,
-		"name": "THE JET BRIGADE 2",
+		"name": "THE JET BRIGADE",
 		"description": "The Automatons have deployed a new series of specialized models on this planet. These upgraded bots utilize stolen Jump Pack technology, heartlessly pillaged from the bodies of fallen Helldivers and reverse-engineered into something nearly unrecognizeable."
 	},
 	"1204": {
@@ -144,10 +144,25 @@
 		"name": "MOVING PLANET",
 		"description": "This planet is moving and is estimated to impact Super Earth."
 	},
+	"1244": {
+		"galacticEffectId": 1244,
+		"name": "PREDATOR STRAIN (Enemies)",
+		"description": "A Gloom-enhanced strain of Terminids has been reported on this planet. SEAF patrols have been lured into ambushes, and picked off by unseen assailants. Every ounce of a Helldiver's superior senses will be required to hunt down this dangerous threat."
+	},
 	"1245": {
 		"galacticEffectId": 1245,
 		"name": "PREDATOR STRAIN",
 		"description": "A Gloom-enhanced strain of Terminids has been reported on this planet. SEAF patrols have been lured into ambushes, and picked off by unseen assailants. Every ounce of a Helldiver's superior senses will be required to hunt down this dangerous threat."
+	},
+	"1246": {
+		"galacticEffectId": 1246,
+		"name": "CAMPAIGN BLOCKER",
+		"description": "Campaigns cannot be launched."
+	},
+	"1248": {
+		"galacticEffectId": 1248,
+		"name": "THE INCINERATION CORPS (Enemies)",
+		"description": "An Automaton unit equipped with flame throwers and incendiary ammunition is active on this planet. These wanton arsonists will not rest until they have razed all that humankind holds dear."
 	},
 	"1249": {
 		"galacticEffectId": 1249,

--- a/effects/planetEffects.json
+++ b/effects/planetEffects.json
@@ -99,6 +99,11 @@
 		"name": "MERIDIAN BLACK HOLE",
 		"description": "The prosperous Meridia was corrupted into a Terminid Supercolony, necessitating its destruction using the mysterious Dark Fluid.  This galactic scar is all that remains."
 	},
+	"1230": {
+		"galacticEffectId": 1230,
+		"name": "MERIDIAN BLACK HOLE",
+		"description": "The prosperous Meridia was corrupted into a Terminid Supercolony, necessitating its destruction using the mysterious Dark Fluid. This galactic scar is all that remains. Advisory: volatile spacetime fluctuations currently prohibit FTL travel to the Meridian Black Hole."
+	},
 	"1232": {
 		"galacticEffectId": 1232,
 		"name": "FACTORY HUB",
@@ -114,10 +119,29 @@
 		"name": "CENTER FOR CIVILIAN SURVEILLANCE AND SAFETY",
 		"description": "The Ministry of Truth analyzes citizens' activity, speech, data, DNA, RNA, and neural topology here."
 	},
-	"1239":{
+	"1238": {
+		"galacticEffectId": 1238,
+		"name": "OPERATIONAL SUPPORT",
+		"description": "The presence of the DSS near this planet provides a slight boost to <i=1>Liberation Campaign</i> progress."
+	},
+	"1239": {
 		"galacticEffectId": 1239,
 		"name": "JET BRIGADE FACTORIES",
 		"description": "Vertically enhanced Jet Brigade soldiers are produced here."
-
+	},
+	"1240": {
+		"galacticEffectId": 1240,
+		"name": "VERGE OF DESTRUCTION",
+		"description": "This planet is under threat of destruction."
+	},
+	"1241": {
+		"galacticEffectId": 1241,
+		"name": "FRACTURED PLANET",
+		"description": "All that remains of a planet torn apart by the Meridian singularity. A solemn reminder of the desolation Tyranny leaves in its wake."
+	},
+	"1242": {
+		"galacticEffectId": 1242,
+		"name": "MOVING SINGULARITY",
+		"description": "The singluarity is moving and is estimated to impact Super Earth."
 	}
 }

--- a/effects/planetEffects.json
+++ b/effects/planetEffects.json
@@ -141,7 +141,12 @@
 	},
 	"1242": {
 		"galacticEffectId": 1242,
-		"name": "MOVING SINGULARITY",
-		"description": "The singularity is moving and is estimated to impact Super Earth."
+		"name": "MOVING WORLD",
+		"description": "This world is moving and is estimated to impact Super Earth."
+	},
+	"1245":{
+		"galacticEffectId": 1245,
+		"name": "PREDATOR STRAIN",
+		"description": "A Gloom-enhanced strain of Terminids has been reported on this planet. SEAF patrols have been lured into ambushes, and picked off by unseen assailants. Every ounce of a Helldiver's superior senses will be required to hunt down this dangerous threat."
 	}
 }


### PR DESCRIPTION
Adding the newly revealed PlanetEffects to the planetEffects.json file.

Included:
1: Fractured Planet (Effect 1241,)
2: Operational Support (Effect 1238, applied by the DSS as a passive)
3: Verge of Destruction (Effect 1240, applied to planets threatened by the moving Meridia)
4: Moving Singularity (Effect 1242, applied to Meridia now.  It adds a purple line connecting it with Super Earth)