### PR TITLE
Create planetRegion.json

### DIFF
--- a/planets/planetRegion.json
+++ b/planets/planetRegion.json
@@ -1,0 +1,30 @@
+{
+	"550918906": {
+		"name": "Equality-on-Sea",
+		"description": "Named for the historic conference where Humanity was found to be the most Equal species in the Galaxy."
+	},
+	"1199462527": {
+		"name": "Rememberance",
+		"description": "Risen from the ashes of an ancient city, Rememberance is a monument to the Perseverance of Humankind."
+	},
+	"4196558004": {
+		"name": "Eagleopolis",
+		"description": "This Great Heart of Commerce is renowned galaxy-wide for its Grand Shopping Malls and Splendorous Entertainment Centers."
+	},
+	"502504685": {
+		"name": "Port Mercy",
+		"description": "Since sheltering millions of loyal refugees in the Last Great War, Port Mercy has been a safe haven for any class-A citizen in need."
+	},
+	"1750980320": {
+		"name": "Prosperity City",
+		"description": "Home to the Democratic Council, our proud Capital is a beacon of Progress, Productivity, and Patriotism."
+	},
+	"3958784315": {
+		"name": "Administrative Center 02",
+		"description": "Each form and application that passes through the hallowed halls of AdminCen is emblazoned with the Stamp of Ages, and should be given a place of honor in the home."
+	},
+	"391918492": {
+		"name": "York Supreme",
+		"description": "Following the Great York Conundrum, one City rose above the rest, pledging to hold its Hand over all other Yorks, so that no more blood be spilt between them."
+	}
+}


### PR DESCRIPTION
Mapping each hash to planet region for Super Earth.

can be mapped via the the settings hash in warInfo.  {"planetIndex":0,"regionIndex":0,"settingsHash":4196558004,"maxHealth":600000,"regionSize":3}