### PR TITLE
Major order task locations

### DIFF
--- a/assignments/tasks/task/valueTypes.json
+++ b/assignments/tasks/task/valueTypes.json
@@ -5,6 +5,6 @@
 	"4": "unit_id",
 	"5": "item_id",
 	"9": "difficulty",
-	"12": "planet_index"
 	"11": "location_type",
+	"12": "location_index"
 }

--- a/assignments/tasks/task/valueTypes.json
+++ b/assignments/tasks/task/valueTypes.json
@@ -5,6 +5,6 @@
 	"4": "unit_id",
 	"5": "item_id",
 	"9": "difficulty",
-	"11": "liberate",
 	"12": "planet_index"
+	"11": "location_type",
 }


### PR DESCRIPTION
The current MO (2368689649) refers to a _sector_ instead of a planet. Turns out the "planet_index" is more like a "location_index" whereas the "liberate" (value type 11) appears to indicate the type of location and is therefore renamed to "location_type" in this PR.

Renaming is a breaking change to anyone who relies on the value type's name, so renaming might not be an option and may have to be reverted / the PR rejected.