### PR TITLE
Fixing Spore Burst Strain Enemies

### DIFF
--- a/effects/planetEffects.json
+++ b/effects/planetEffects.json
@@ -286,7 +286,7 @@
 	},
 	"1214": {
 		"galacticEffectId": 1214,
-		"name": "PLANETARY BOMBARDMENT",
+		"name": "BOMBARDMENT LIBERATION BOOST",
 		"description": "Progress in Liberation Campaigns is accelerated by 150%."
 	},
 	"1217": {

--- a/effects/planetEffects.json
+++ b/effects/planetEffects.json
@@ -384,10 +384,15 @@
 		"name": "MOVING PLANET",
 		"description": "This planet is moving and is estimated to impact Super Earth."
 	},
-	"1244": {
-		"galacticEffectId": 1244,
+	"1243": {
+		"galacticEffectId": 1243,
 		"name": "PREDATOR STRAIN (Enemies)",
 		"description": "A Gloom-enhanced strain of Terminids has been reported on this planet. SEAF patrols have been lured into ambushes, and picked off by unseen assailants. Every ounce of a Helldiver's superior senses will be required to hunt down this dangerous threat."
+	},
+	"1244": {
+		"galacticEffectId": 1244,
+		"name": "Spore Burst Strain (Enemies)",
+		"description": "A Gloom-enhanced strain of Terminids has been reported on this planet. They can explode into spores."
 	},
 	"1245": {
 		"galacticEffectId": 1245,
@@ -508,11 +513,17 @@
 		"galacticEffectId": 1286,
 		"name": "NEW HOPE CONSTRUCTION SITE",
 		"description": "One of 3 Maximum Security Cities is under construction here."
-<<<<<<< HEAD
 	},	
-=======
+	"1287": {
+		"galacticEffectId": 1287,
+		"name": "NEW HOPE CITY",
+		"description": "The flagship Maximum Security City. Impregnable to Tyranny; the future of the Federation."
 	},
->>>>>>> 5464565645cceb10216dbe1b0ac5f1b2d213b484
+	"1286": {
+		"galacticEffectId": 1286,
+		"name": "NEW HOPE CONSTRUCTION SITE",
+		"description": "One of 3 Maximum Security Cities is under construction here."
+	},
 	"1287": {
 		"galacticEffectId": 1287,
 		"name": "NEW HOPE CITY",

--- a/effects/planetEffects.json
+++ b/effects/planetEffects.json
@@ -194,9 +194,29 @@
 		"name": "IMPALER RAMPAGE",
 		"description": "Significantly higher Impaler numbers have been observed on this planet."
 	},
+	"1286": {
+		"galacticEffectId": 1286,
+		"name": "NEW HOPE CONSTRUCTION SITE",
+		"description": "One of 3 Maximum Security Cities is under construction here."
+	},	
+	"1287": {
+		"galacticEffectId": 1287,
+		"name": "NEW HOPE CITY",
+		"description": "The flagship Maximum Security City. Impregnable to Tyranny; the future of the Federation."
+	},
 	"1288": {
 		"galacticEffectId": 1288,
 		"name": "SPORE BURST SCAVENGER RAMPAGE",
 		"description": "Significantly increased levels of Spore Burst Scavengers have been reported on this planet."
+	},
+	"1291": {
+		"galacticEffectId": 1291,
+		"name": "NEW ASPIRATION CITY",
+		"description": "One of 3 Maximum Security Cities. Impregnable to Tyranny; the future of the Federation."
+	},
+	"1292": {
+		"galacticEffectId": 1292,
+		"name": "NEW YEARNING CITY",
+		"description": "One of 3 Maximum Security Cities. Impregnable to Tyranny; the future of the Federation."
 	}
 }

--- a/effects/planetEffects.json
+++ b/effects/planetEffects.json
@@ -513,16 +513,6 @@
 		"galacticEffectId": 1286,
 		"name": "NEW HOPE CONSTRUCTION SITE",
 		"description": "One of 3 Maximum Security Cities is under construction here."
-	},	
-	"1287": {
-		"galacticEffectId": 1287,
-		"name": "NEW HOPE CITY",
-		"description": "The flagship Maximum Security City. Impregnable to Tyranny; the future of the Federation."
-	},
-	"1286": {
-		"galacticEffectId": 1286,
-		"name": "NEW HOPE CONSTRUCTION SITE",
-		"description": "One of 3 Maximum Security Cities is under construction here."
 	},
 	"1287": {
 		"galacticEffectId": 1287,

--- a/planets/planetRegion.json
+++ b/planets/planetRegion.json
@@ -187,6 +187,10 @@
 		"name": "BROKER'S WEALTH",
 		"description": ""
 	},
+	"1193052974": {
+		"name": "NEW ASPIRATION CITY",
+		"description": "One of 3 Maximum Security Cities. Impregnable to Tyranny; the future of the Federation."
+	},
 	"16522331": {
 		"name": "FARMHANDSTOWN",
 		"description": ""
@@ -228,12 +232,16 @@
 		"description": ""
 	},
 	"189783404": {
-		"name": "PSEUDOTOPIA",
+		"name": "PSEUDOTOPIA", 
 		"description": ""
 	},
 	"3342476592": {
 		"name": "FAMEWOLF PEAK",
 		"description": ""
+	},
+	"27836851": {
+		"name": "NEW YEARNING CITY",
+		"description": "One of 3 Maximum Security Cities. Impregnable to Tyranny; the future of the Federation."
 	},
 	"2557369266": {
 		"name": "OTARU'S PLEDGE",
@@ -246,6 +254,10 @@
 	"991650372": {
 		"name": "MUNITION CITY",
 		"description": ""
+	},
+	"1239520232": {
+		"name": "NEW HOPE CITY",
+		"description": "The flagship Maximum Security City. Impregnable to Tyranny; the future of the Federation."
 	},
 	"3900513024": {
 		"name": "VÁHTJER",

--- a/planets/planetRegion.json
+++ b/planets/planetRegion.json
@@ -232,7 +232,7 @@
 		"description": ""
 	},
 	"189783404": {
-		"name": "PSEUDOTOPIA", 
+		"name": "PSEUDOTOPIA",
 		"description": ""
 	},
 	"3342476592": {


### PR DESCRIPTION
Fixing the Spore Burst Strain to use the right enemy id.

